### PR TITLE
Expose more of the Gson API in IGsonProvider and DefaultGsonProvider

### DIFF
--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/DefaultGsonProvider.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/DefaultGsonProvider.java
@@ -8,8 +8,8 @@ import java.lang.reflect.Type;
 
 public class DefaultGsonProvider implements IGsonProvider {
 
-    private final GsonBuilder gsonBuilder;
-    private Gson gson;
+    protected final GsonBuilder gsonBuilder;
+    protected Gson gson;
 
     public DefaultGsonProvider(){
         this.gsonBuilder = new GsonBuilder();

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/DefaultGsonProvider.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/DefaultGsonProvider.java
@@ -2,6 +2,7 @@ package com.coreyd97.BurpExtenderUtilities;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapterFactory;
 
 import java.lang.reflect.Type;
 
@@ -23,6 +24,18 @@ public class DefaultGsonProvider implements IGsonProvider {
     @Override
     public void registerTypeAdapter(Type type, Object typeAdapter) {
         this.gsonBuilder.registerTypeAdapter(type, typeAdapter);
+        this.gson = this.gsonBuilder.create();
+    }
+
+    @Override
+    public void registerTypeHierarchyAdapter(Class<?> clazz, Object adapater){
+        this.gsonBuilder.registerTypeHierarchyAdapter(clazz, adapater);
+        this.gson = this.gsonBuilder.create();
+    }
+
+    @Override
+    public void registerTypeAdapterFactory(TypeAdapterFactory factory){
+        this.gsonBuilder.registerTypeAdapterFactory(factory);
         this.gson = this.gsonBuilder.create();
     }
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/IGsonProvider.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/IGsonProvider.java
@@ -2,6 +2,7 @@ package com.coreyd97.BurpExtenderUtilities;
 
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
 
 import java.lang.reflect.Type;
 
@@ -16,4 +17,8 @@ public interface IGsonProvider {
      * @param typeAdapter
      */
     void registerTypeAdapter(Type type, Object typeAdapter);
+
+    void registerTypeHierarchyAdapter(Class<?> clazz, Object adapater);
+
+    void registerTypeAdapterFactory(TypeAdapterFactory factory);
 }


### PR DESCRIPTION
This would allow users more control over the Gson object.
For example, Gson does not have a default adapter for the `Path` type. `Path` is an interface, so with only the exposed `registerTypeAdapter()` method, separate adapters would need to be registered for each different implementation of `Path` even though basically every `Path` implementation should have the same JSON serialized representation.

Exposing the `registerTypeHierarchyAdapter()` method allows users to handle this situation more gracefully by only having to register a single adapter for the parent type.

`registerTypeAdapterFactory()` can be used in similar situations.