### PR TITLE
Feature/name manager collision detection

### DIFF
--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/GsonUtilities.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/GsonUtilities.java
@@ -1,0 +1,13 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+
+public class GsonUtilities{
+  public static <T> T clone(T src, Type type, Gson gson){
+    String jsonDefaultValue = gson.toJson(src);
+    return gson.fromJson(jsonDefaultValue, type);
+  }
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/KeyNotReservedException.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/KeyNotReservedException.java
@@ -1,0 +1,20 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+public class KeyNotReservedException extends RuntimeException{
+  public KeyNotReservedException(){}
+
+  public KeyNotReservedException(String message){ super(message); }
+
+  public KeyNotReservedException(String message, Throwable cause){
+    super(message, cause);
+  }
+
+  public KeyNotReservedException(
+    String message, Throwable cause,
+    boolean enableSuppression, boolean writableStackTrace
+  ){
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public KeyNotReservedException(Throwable cause){ super(cause); }
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/NameCollisionException.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/NameCollisionException.java
@@ -1,0 +1,20 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+public class NameCollisionException extends RuntimeException{
+  public NameCollisionException()              {}
+
+  public NameCollisionException(String message){ super(message); }
+
+  public NameCollisionException(String message, Throwable cause){
+    super(message, cause);
+  }
+
+  public NameCollisionException(
+    String message, Throwable cause,
+    boolean enableSuppression, boolean writableStackTrace
+  ){
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public NameCollisionException(Throwable cause){ super(cause); }
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/NameManager.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/NameManager.java
@@ -1,0 +1,21 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class NameManager{
+  public static void reserve(String newName){
+    if(!_nameSet.add(newName))
+      throw new NameCollisionException("Name " + newName + " is already reserved.");
+  }
+
+  public static void release(String name){
+    //this might not actually need to throw an exception... it may not be useful... not sure
+    if(!_nameSet.remove(name))
+      throw new KeyNotReservedException("Name " + name + " was not previously reserved.");
+  }
+
+  public static boolean isReserved(String name){ return _nameSet.contains(name); }
+
+  private static final Set<String> _nameSet = new HashSet<>();
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
@@ -18,6 +18,6 @@ public abstract class PersistedContainer{
 
   public void reregister(){ _prefs.reregister(_PERSISTED_NAME); }
 
-  protected transient final String        _PERSISTED_NAME;
-  protected transient final Preferences   _prefs;
+  protected transient final String      _PERSISTED_NAME;
+  protected transient final Preferences _prefs;
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
@@ -18,6 +18,6 @@ public abstract class PersistedContainer{
 
   public void reregister(){ _prefs.reregister(_PERSISTED_NAME); }
 
-  protected transient final String      _PERSISTED_NAME;
-  protected transient final Preferences _prefs;
+  protected transient final String        _PERSISTED_NAME;
+  protected transient final Preferences   _prefs;
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
@@ -35,19 +35,13 @@ extends PersistedContainer{
   //  needs to be handled by the child class
   protected void reset(){ _prefs.reset(_PERSISTED_NAME); }
 
-  //calls child class no-arg constructor
-  //  to get the default value of the object
   protected void register(){
-    try{
-      Class<?> thisClazz = this.getClass();
-      Constructor<?> constr = thisClazz.getDeclaredConstructor();
-      constr.setAccessible(true);
-      this.register(thisClazz, constr.newInstance());
-    }
-    catch(NoSuchMethodException | InvocationTargetException |
-      InstantiationException | IllegalAccessException e){
-      throw new RuntimeException(e);
-    }
+    Class<?> thisClazz = this.getClass();
+    PersistedObject thisDefaultClone = GsonUtilities.clone(
+      this, thisClazz, _prefs.getGsonProvider().getGson()
+    );
+
+    this.register(thisClazz, thisDefaultClone);
   }
 
   protected void register(Type persistedType, Object defaultValue){
@@ -55,11 +49,4 @@ extends PersistedContainer{
   }
 
   private final transient Preferences.Visibility _vis;
-
-  //DO NOT USE!
-  //disabled no-arg constructor
-  private PersistedObject(){
-    super(null, null, null);
-    _vis = null;
-  }
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
@@ -99,8 +99,9 @@ public class Preferences {
         register(settingName, type, defaultValue, visibility, true);
     }
 
-    public void register(String settingName, Type type, Object defaultValue, Visibility visibility, Boolean persistDefault) {
-        throwExceptionIfAlreadyRegistered(settingName);
+    public void register(String settingName, Type type, Object defaultValue, Visibility visibility, Boolean persistDefault){
+        NameManager.reserve(settingName);
+
         this.preferenceVisibilities.put(settingName, visibility);
         this.preferenceTypes.put(settingName, type);
         this.preferenceDefaults.put(settingName, defaultValue);

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
@@ -116,7 +116,7 @@ public class Preferences {
             this.preferences.put(settingName, previousValue);
         }else{
             if(persistDefault) reset(settingName);
-            else               this.preferences.put(settingName, clone(defaultValue, type));
+            else               this.preferences.put(settingName, cloneDefault(settingName));
         }
 
         logOutput(String.format("Registered setting: [Key=%s, Scope=%s, Type=%s, Default=%s, Value=%s, Persisted=%s]",
@@ -318,8 +318,7 @@ public class Preferences {
         Visibility visibility = this.preferenceVisibilities.get(settingName);
         if(visibility == null) throw new RuntimeException("Setting " + settingName + " has not been registered!");
 
-        Object defaultValue = this.preferenceDefaults.getOrDefault(settingName, null);
-        Object newInstance = clone(defaultValue, this.preferenceTypes.get(settingName));
+        Object newInstance = cloneDefault(settingName);
 
         this.setSetting(settingName, newInstance);
 
@@ -365,9 +364,20 @@ public class Preferences {
             logProvider.logError(errorMessage);
     }
 
-    private Object clone(Object original, Type type){
-        String jsonDefaultValue = gsonProvider.getGson().toJson(original);
-        return gsonProvider.getGson().fromJson(jsonDefaultValue, type);
+    private Object cloneSetting(String settingName){
+        throwExceptionIfNotPreviouslyRegistered(settingName);
+        Type type  = preferenceTypes.get(settingName);
+        Object src = preferences.get(settingName);
+
+        return GsonUtilities.clone(src, type, gsonProvider.getGson());
+    }
+
+    private Object cloneDefault(String settingName){
+        throwExceptionIfNotPreviouslyRegistered(settingName);
+        Type type  = preferenceTypes.get(settingName);
+        Object src = preferenceDefaults.get(settingName);
+
+        return GsonUtilities.clone(src, type, gsonProvider.getGson());
     }
 
     private void throwExceptionIfAlreadyRegistered(String settingName){


### PR DESCRIPTION
### _This_ PR should only be considered AFTER [this other PR (12)](https://github.com/CoreyD97/Burp-Montoya-Utilities/pull/12), because _this_ PR's commit history is based on the other's. If the other PR gets rejected, I will refactor this PR's code to not depend on it.

---
This change:
--------------
- Creates a `NameManager` class a related custom exception classes.
  - The name manager class is a static class (only has static data and methods) that merely provides a way for different `Preferences` to coordinate with each other to be able to detect registered `settingsName`s and notify the user with an exception if they try to do something stupid.
- Implements the coordination between different `Preferences` instances using the `NameManager`

This change allows each `Persisted*` and `PreferenceFactory` to have their own instance of `Preferences` without sacrificing the benefit of key collision detection if you were to use a single shared `Preferences` instance. This in turn allows `Persisted*`s and `PreferenceFactory`s to have their own `IGsonProvider`s allowing for flexible and contextually customizable serialization / deserialization with an API that is consistent with GSON's own API.

Example Usage
-----------------
A sample Burp Extension that uses these features can be found [here](https://github.com/CrazyKidJack/TestBurpExtensionGradle/blob/main/src/main/java/com/jSoft/burp/Main.java).

Please note that it also uses some other features for which I have submitted PRs but that may not yet have been pulled into this repo. A working version of a fork of _this_ repo with all features used by the sample extension can be found [here (tag 1.1.0-beta.0.2.1)](https://github.com/CrazyKidJack/Burp-Montoya-Utilities/tree/1.1.0-beta.0.2.1).

If you trust them, I have created releases with jars that you can load and run to save you the trouble of building:
- [BurpMontoyaUtilities](https://github.com/CrazyKidJack/Burp-Montoya-Utilities/releases/tag/1.1.0-beta.0.2.1)
- [Sample Extension](https://github.com/CrazyKidJack/TestBurpExtensionGradle/releases/tag/0.0.0-beta.0.2.0)