### PR TITLE
Feature/namespaces

### DIFF
--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/GsonUtilities.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/GsonUtilities.java
@@ -1,0 +1,13 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+
+public class GsonUtilities{
+  public static <T> T clone(T src, Type type, Gson gson){
+    String jsonDefaultValue = gson.toJson(src);
+    return gson.fromJson(jsonDefaultValue, type);
+  }
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/KeyNotReservedException.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/KeyNotReservedException.java
@@ -1,0 +1,20 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+public class KeyNotReservedException extends RuntimeException{
+  public KeyNotReservedException(){}
+
+  public KeyNotReservedException(String message){ super(message); }
+
+  public KeyNotReservedException(String message, Throwable cause){
+    super(message, cause);
+  }
+
+  public KeyNotReservedException(
+    String message, Throwable cause,
+    boolean enableSuppression, boolean writableStackTrace
+  ){
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public KeyNotReservedException(Throwable cause){ super(cause); }
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/NameCollisionException.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/NameCollisionException.java
@@ -1,0 +1,20 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+public class NameCollisionException extends RuntimeException{
+  public NameCollisionException()              {}
+
+  public NameCollisionException(String message){ super(message); }
+
+  public NameCollisionException(String message, Throwable cause){
+    super(message, cause);
+  }
+
+  public NameCollisionException(
+    String message, Throwable cause,
+    boolean enableSuppression, boolean writableStackTrace
+  ){
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+  public NameCollisionException(Throwable cause){ super(cause); }
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/NameManager.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/NameManager.java
@@ -1,0 +1,21 @@
+package com.coreyd97.BurpExtenderUtilities;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class NameManager{
+  public static void reserve(String newName){
+    if(!_nameSet.add(newName))
+      throw new NameCollisionException("Name " + newName + " is already reserved.");
+  }
+
+  public static void release(String name){
+    //this might not actually need to throw an exception... it may not be useful... not sure
+    if(!_nameSet.remove(name))
+      throw new KeyNotReservedException("Name " + name + " was not previously reserved.");
+  }
+
+  public static boolean isReserved(String name){ return _nameSet.contains(name); }
+
+  private static final Set<String> _nameSet = new HashSet<>();
+}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedCollection.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedCollection.java
@@ -15,28 +15,28 @@ import java.util.stream.Stream;
 public class PersistedCollection<E, CollectionT extends Collection<E>>
 extends PersistedContainer implements Collection<E>{
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis
+    final MontoyaApi api, final String name, final Preferences.Visibility vis
   ){
     this(api, name, vis, new TypeToken<CollectionT>(){});
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends CollectionT> collectionType
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends CollectionT> collectionType
   ){
     this(api, name, vis, collectionType, (CollectionT)null);
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    CollectionT defaultCollection
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final CollectionT defaultCollection
   ){
     this(api, name, vis, new TypeToken<CollectionT>(){}, defaultCollection);
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends CollectionT> collectionType, final CollectionT defaultCollection
   ){
     this(
       api, name, vis,
@@ -46,9 +46,9 @@ extends PersistedContainer implements Collection<E>{
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends CollectionT> collectionType, final CollectionT defaultCollection
   ){
     this(
       api, name, vis,
@@ -59,24 +59,24 @@ extends PersistedContainer implements Collection<E>{
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final String namespace
   ){
     this(api, name, vis, new TypeToken<CollectionT>(){}, namespace);
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends CollectionT> collectionType,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends CollectionT> collectionType,
+    final String namespace
   ){
     this(api, name, vis, collectionType, null, namespace);
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    CollectionT defaultCollection,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final CollectionT defaultCollection,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -86,9 +86,9 @@ extends PersistedContainer implements Collection<E>{
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends CollectionT> collectionType, final CollectionT defaultCollection,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -99,10 +99,10 @@ extends PersistedContainer implements Collection<E>{
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends CollectionT> collectionType, final CollectionT defaultCollection,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -113,10 +113,10 @@ extends PersistedContainer implements Collection<E>{
   }
 
   public PersistedCollection(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider, ILogProvider logProvider,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider, final ILogProvider logProvider,
+    final TypeToken<? extends CollectionT> collectionType, final CollectionT defaultCollection,
+    final String namespace
   ){
     super(api, name, gsonProvider, logProvider, namespace);
     _prefs.register(name, collectionType.getType(), defaultCollection, vis);

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedCollection.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedCollection.java
@@ -15,52 +15,110 @@ import java.util.stream.Stream;
 public class PersistedCollection<E, CollectionT extends Collection<E>>
 extends PersistedContainer implements Collection<E>{
   public PersistedCollection(
-    MontoyaApi api,
-    String name,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis
   ){
-    this(api, name, new TypeToken<CollectionT>(){}, vis);
+    this(api, name, vis, new TypeToken<CollectionT>(){});
   }
 
   public PersistedCollection(
-    MontoyaApi api,
-    String name,
-    TypeToken<? extends CollectionT> collectionType,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends CollectionT> collectionType
   ){
-    this(api, name, collectionType, null, vis);
+    this(api, name, vis, collectionType, (CollectionT)null);
   }
 
   public PersistedCollection(
-    MontoyaApi api,
-    String name,
-    CollectionT defaultCollection,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    CollectionT defaultCollection
   ){
-    this(api, name, new TypeToken<CollectionT>(){}, defaultCollection, vis);
+    this(api, name, vis, new TypeToken<CollectionT>(){}, defaultCollection);
   }
 
   public PersistedCollection(
-    MontoyaApi api,
-    String name,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection
   ){
     this(
-      api, new DefaultGsonProvider(),
-      name,
-      collectionType, defaultCollection,
-      vis
+      api, name, vis,
+      new DefaultGsonProvider(),
+      collectionType, defaultCollection
     );
   }
 
   public PersistedCollection(
-    MontoyaApi api, IGsonProvider gsonProvider,
-    String name,
-    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection
   ){
-    super(api, gsonProvider, name);
+    this(
+      api, name, vis,
+      gsonProvider,
+      collectionType, defaultCollection,
+      ""
+    );
+  }
+
+  public PersistedCollection(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    String namespace
+  ){
+    this(api, name, vis, new TypeToken<CollectionT>(){}, namespace);
+  }
+
+  public PersistedCollection(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends CollectionT> collectionType,
+    String namespace
+  ){
+    this(api, name, vis, collectionType, null, namespace);
+  }
+
+  public PersistedCollection(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    CollectionT defaultCollection,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new TypeToken<CollectionT>(){}, defaultCollection,
+      namespace
+    );
+  }
+
+  public PersistedCollection(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(),
+      collectionType, defaultCollection,
+      namespace
+    );
+  }
+
+  public PersistedCollection(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), null,
+      collectionType, defaultCollection,
+      namespace
+    );
+  }
+
+  public PersistedCollection(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider, ILogProvider logProvider,
+    TypeToken<? extends CollectionT> collectionType, CollectionT defaultCollection,
+    String namespace
+  ){
+    super(api, name, gsonProvider, logProvider, namespace);
     _prefs.register(name, collectionType.getType(), defaultCollection, vis);
     _internalCollection = _prefs.get(name);
   }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
@@ -3,35 +3,35 @@ package com.coreyd97.BurpExtenderUtilities;
 import burp.api.montoya.MontoyaApi;
 
 public abstract class PersistedContainer{
-  public PersistedContainer(MontoyaApi api, String name){
+  public PersistedContainer(final MontoyaApi api, final String name){
     this(api, name, new DefaultGsonProvider());
   }
 
-  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider){
+  public PersistedContainer(final MontoyaApi api, final String name, final IGsonProvider gsonProvider){
     this(api, name, gsonProvider, (ILogProvider)null);
   }
 
-  public PersistedContainer(MontoyaApi api, String name, ILogProvider logProvider){
+  public PersistedContainer(final MontoyaApi api, final String name, final ILogProvider logProvider){
     this(api, name, new DefaultGsonProvider(), (ILogProvider)null);
   }
 
-  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider, ILogProvider logProvider){
+  public PersistedContainer(final MontoyaApi api, final String name, final IGsonProvider gsonProvider, final ILogProvider logProvider){
     this(api, name, gsonProvider, logProvider, "");
   }
 
-  public PersistedContainer(MontoyaApi api, String name, String namespace){
+  public PersistedContainer(final MontoyaApi api, final String name, final String namespace){
     this(api, name, new DefaultGsonProvider(), namespace);
   }
 
-  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider, String namespace){
+  public PersistedContainer(final MontoyaApi api, final String name, final IGsonProvider gsonProvider, final String namespace){
     this(api, name, gsonProvider, null, namespace);
   }
 
-  public PersistedContainer(MontoyaApi api, String name, ILogProvider logProvider, String namespace){
+  public PersistedContainer(final MontoyaApi api, final String name, final ILogProvider logProvider, final String namespace){
     this(api, name, new DefaultGsonProvider(), logProvider, namespace);
   }
 
-  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider, ILogProvider logProvider, String namespace){
+  public PersistedContainer(final MontoyaApi api, final String name, final IGsonProvider gsonProvider, final ILogProvider logProvider, final String namespace){
     _PERSISTED_NAME = name;
     _prefs = new Preferences(api, gsonProvider, logProvider, namespace);
   }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
@@ -4,12 +4,36 @@ import burp.api.montoya.MontoyaApi;
 
 public abstract class PersistedContainer{
   public PersistedContainer(MontoyaApi api, String name){
-    this(api, new DefaultGsonProvider(), name);
+    this(api, name, new DefaultGsonProvider());
   }
 
-  public PersistedContainer(MontoyaApi api, IGsonProvider gsonProvider, String name){
+  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider){
+    this(api, name, gsonProvider, (ILogProvider)null);
+  }
+
+  public PersistedContainer(MontoyaApi api, String name, ILogProvider logProvider){
+    this(api, name, new DefaultGsonProvider(), (ILogProvider)null);
+  }
+
+  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider, ILogProvider logProvider){
+    this(api, name, gsonProvider, logProvider, "");
+  }
+
+  public PersistedContainer(MontoyaApi api, String name, String namespace){
+    this(api, name, new DefaultGsonProvider(), namespace);
+  }
+
+  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider, String namespace){
+    this(api, name, gsonProvider, null, namespace);
+  }
+
+  public PersistedContainer(MontoyaApi api, String name, ILogProvider logProvider, String namespace){
+    this(api, name, new DefaultGsonProvider(), logProvider, namespace);
+  }
+
+  public PersistedContainer(MontoyaApi api, String name, IGsonProvider gsonProvider, ILogProvider logProvider, String namespace){
     _PERSISTED_NAME = name;
-    _prefs = new Preferences(api, gsonProvider);
+    _prefs = new Preferences(api, gsonProvider, logProvider, namespace);
   }
 
   public void save(){ _prefs.set(_PERSISTED_NAME, this); }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedContainer.java
@@ -18,6 +18,6 @@ public abstract class PersistedContainer{
 
   public void reregister(){ _prefs.reregister(_PERSISTED_NAME); }
 
-  protected transient final String      _PERSISTED_NAME;
-  protected transient final Preferences _prefs;
+  protected transient final String        _PERSISTED_NAME;
+  protected transient final Preferences   _prefs;
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedList.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedList.java
@@ -11,47 +11,102 @@ import java.util.function.UnaryOperator;
 
 public class PersistedList<E> extends PersistedCollection<E, List<E>> implements List<E>{
   public PersistedList(
-    MontoyaApi api,
-    String name,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis
   ){
-    super(api, name, new TypeToken<List<E>>(){}, vis);
+    super(api, name, vis, new TypeToken<List<E>>(){});
   }
 
   public PersistedList(
-    MontoyaApi api,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends List<E>> listType
+  ){
+    super(api, name, vis, listType);
+  }
+
+  public PersistedList(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    List<E> defaultList
+  ){
+    super(api, name, vis, new TypeToken<List<E>>(){}, defaultList);
+  }
+
+  public PersistedList(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends List<E>> listType, List<E> defaultList
+  ){
+    super(api, name, vis, listType, defaultList);
+  }
+
+  public PersistedList(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    TypeToken<? extends List<E>> listType, List<E> defaultList
+  ){
+    super(api, name, vis, gsonProvider, listType, defaultList);
+  }
+
+  public PersistedList(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    String namespace
+  ){
+    super(api, name, vis, new TypeToken<List<E>>(){}, namespace);
+  }
+
+  public PersistedList(
+    MontoyaApi api, String name, Preferences.Visibility vis,
     TypeToken<? extends List<E>> listType,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, name, listType, vis);
+    super(api, name, vis, listType, null, namespace);
   }
 
   public PersistedList(
-    MontoyaApi api,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
     List<E> defaultList,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, name, new TypeToken<List<E>>(){}, defaultList, vis);
+    super(api, name, vis, new TypeToken<List<E>>(){}, defaultList, namespace);
   }
 
   public PersistedList(
-    MontoyaApi api,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
     TypeToken<? extends List<E>> listType, List<E> defaultList,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, name, listType, defaultList, vis);
+    super(
+      api, name, vis,
+      new DefaultGsonProvider(),
+      listType, defaultList,
+      namespace
+    );
   }
 
   public PersistedList(
-    MontoyaApi api, IGsonProvider gsonProvider,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
     TypeToken<? extends List<E>> listType, List<E> defaultList,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, gsonProvider, name, listType, defaultList, vis);
+    super(
+      api, name, vis,
+      new DefaultGsonProvider(), null,
+      listType, defaultList,
+      namespace
+    );
+  }
+
+  public PersistedList(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider, ILogProvider logProvider,
+    TypeToken<? extends List<E>> listType, List<E> defaultList,
+    String namespace
+  ){
+    super(
+      api, name, vis,
+      gsonProvider, logProvider,
+      listType, defaultList,
+      namespace
+    );
   }
 
   //////////////

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedList.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedList.java
@@ -11,67 +11,67 @@ import java.util.function.UnaryOperator;
 
 public class PersistedList<E> extends PersistedCollection<E, List<E>> implements List<E>{
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis
+    final MontoyaApi api, final String name, final Preferences.Visibility vis
   ){
     super(api, name, vis, new TypeToken<List<E>>(){});
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends List<E>> listType
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends List<E>> listType
   ){
     super(api, name, vis, listType);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    List<E> defaultList
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final List<E> defaultList
   ){
     super(api, name, vis, new TypeToken<List<E>>(){}, defaultList);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends List<E>> listType, List<E> defaultList
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends List<E>> listType, final List<E> defaultList
   ){
     super(api, name, vis, listType, defaultList);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends List<E>> listType, List<E> defaultList
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends List<E>> listType, final List<E> defaultList
   ){
     super(api, name, vis, gsonProvider, listType, defaultList);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final String namespace
   ){
     super(api, name, vis, new TypeToken<List<E>>(){}, namespace);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends List<E>> listType,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends List<E>> listType,
+    final String namespace
   ){
     super(api, name, vis, listType, null, namespace);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    List<E> defaultList,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final List<E> defaultList,
+    final String namespace
   ){
     super(api, name, vis, new TypeToken<List<E>>(){}, defaultList, namespace);
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends List<E>> listType, List<E> defaultList,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends List<E>> listType, final List<E> defaultList,
+    final String namespace
   ){
     super(
       api, name, vis,
@@ -82,10 +82,10 @@ public class PersistedList<E> extends PersistedCollection<E, List<E>> implements
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends List<E>> listType, List<E> defaultList,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends List<E>> listType, final List<E> defaultList,
+    final String namespace
   ){
     super(
       api, name, vis,
@@ -96,10 +96,10 @@ public class PersistedList<E> extends PersistedCollection<E, List<E>> implements
   }
 
   public PersistedList(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider, ILogProvider logProvider,
-    TypeToken<? extends List<E>> listType, List<E> defaultList,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider, final ILogProvider logProvider,
+    final TypeToken<? extends List<E>> listType, final List<E> defaultList,
+    final String namespace
   ){
     super(
       api, name, vis,

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedList.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedList.java
@@ -89,7 +89,7 @@ public class PersistedList<E> extends PersistedCollection<E, List<E>> implements
   ){
     super(
       api, name, vis,
-      new DefaultGsonProvider(), null,
+      gsonProvider, null,
       listType, defaultList,
       namespace
     );

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedMap.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedMap.java
@@ -19,52 +19,106 @@ import java.util.function.Function;
 public class PersistedMap<K,V, MapT extends Map<K,V>>
 extends PersistedContainer implements Map<K,V>{
   public PersistedMap(
-    MontoyaApi api,
-    String name,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis
   ){
-    this(api, name, new TypeToken<MapT>(){}, vis);
+    this(api, name, vis, new TypeToken<MapT>(){});
   }
 
   public PersistedMap(
-    MontoyaApi api,
-    String name,
-    TypeToken<? extends MapT> mapType,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends MapT> mapType
   ){
-    this(api, name, mapType, null, vis);
+    this(api, name, vis, mapType, (MapT)null);
   }
 
   public PersistedMap(
-    MontoyaApi api,
-    String name,
-    MapT defaultMap,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    MapT defaultMap
   ){
-    this(api, name, new TypeToken<MapT>(){}, defaultMap, vis);
+    this(api, name, vis, new TypeToken<MapT>(){}, defaultMap);
   }
 
   public PersistedMap(
-    MontoyaApi api,
-    String name,
-    TypeToken<? extends MapT> mapType, MapT defaultMap,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends MapT> mapType, MapT defaultMap
   ){
     this(
-      api, new DefaultGsonProvider(),
-      name,
-      mapType, defaultMap,
-      vis
+      api, name, vis,
+      new DefaultGsonProvider(),
+      mapType, defaultMap
     );
   }
 
   public PersistedMap(
-    MontoyaApi api, IGsonProvider gsonProvider,
-    String name,
-    TypeToken<? extends MapT> mapType, MapT defaultMap,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    TypeToken<? extends MapT> mapType, MapT defaultMap
   ){
-    super(api, gsonProvider, name);
+    this(
+      api, name, vis,
+      gsonProvider,
+      mapType, defaultMap,
+      ""
+    );
+  }
+
+  public PersistedMap(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    String namespace
+  ){
+    this(api, name, vis, new TypeToken<MapT>(){}, namespace);
+  }
+
+  public PersistedMap(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends MapT> mapType,
+    String namespace
+  ){
+    this(api, name, vis, mapType, null, namespace);
+  }
+
+  public PersistedMap(
+    MontoyaApi api, String name,Preferences.Visibility vis,
+    MapT defaultMap,
+    String namespace
+  ){
+    this(api, name, vis, new TypeToken<MapT>(){}, defaultMap, namespace);
+  }
+
+  public PersistedMap(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends MapT> mapType, MapT defaultMap,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(),
+      mapType, defaultMap,
+      namespace
+    );
+  }
+
+  public PersistedMap(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    TypeToken<? extends MapT> mapType, MapT defaultMap,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), null,
+      mapType, defaultMap,
+      namespace
+    );
+  }
+
+  public PersistedMap(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider, ILogProvider logProvider,
+    TypeToken<? extends MapT> mapType, MapT defaultMap,
+    String namespace
+  ){
+    super(api, name, gsonProvider, logProvider, namespace);
     _prefs.register(name, mapType.getType(), defaultMap, vis);
     _internalMap = _prefs.get(name);
   }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedMap.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedMap.java
@@ -19,28 +19,28 @@ import java.util.function.Function;
 public class PersistedMap<K,V, MapT extends Map<K,V>>
 extends PersistedContainer implements Map<K,V>{
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis
+    final MontoyaApi api, final String name, final Preferences.Visibility vis
   ){
     this(api, name, vis, new TypeToken<MapT>(){});
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends MapT> mapType
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends MapT> mapType
   ){
     this(api, name, vis, mapType, (MapT)null);
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    MapT defaultMap
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final MapT defaultMap
   ){
     this(api, name, vis, new TypeToken<MapT>(){}, defaultMap);
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends MapT> mapType, MapT defaultMap
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends MapT> mapType, final MapT defaultMap
   ){
     this(
       api, name, vis,
@@ -50,9 +50,9 @@ extends PersistedContainer implements Map<K,V>{
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends MapT> mapType, MapT defaultMap
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends MapT> mapType, final MapT defaultMap
   ){
     this(
       api, name, vis,
@@ -63,32 +63,32 @@ extends PersistedContainer implements Map<K,V>{
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final String namespace
   ){
     this(api, name, vis, new TypeToken<MapT>(){}, namespace);
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends MapT> mapType,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends MapT> mapType,
+    final String namespace
   ){
     this(api, name, vis, mapType, null, namespace);
   }
 
   public PersistedMap(
-    MontoyaApi api, String name,Preferences.Visibility vis,
-    MapT defaultMap,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final MapT defaultMap,
+    final String namespace
   ){
     this(api, name, vis, new TypeToken<MapT>(){}, defaultMap, namespace);
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends MapT> mapType, MapT defaultMap,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends MapT> mapType, final MapT defaultMap,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -99,10 +99,10 @@ extends PersistedContainer implements Map<K,V>{
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends MapT> mapType, MapT defaultMap,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends MapT> mapType, final MapT defaultMap,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -113,10 +113,10 @@ extends PersistedContainer implements Map<K,V>{
   }
 
   public PersistedMap(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider, ILogProvider logProvider,
-    TypeToken<? extends MapT> mapType, MapT defaultMap,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider, final ILogProvider logProvider,
+    final TypeToken<? extends MapT> mapType, final MapT defaultMap,
+    final String namespace
   ){
     super(api, name, gsonProvider, logProvider, namespace);
     _prefs.register(name, mapType.getType(), defaultMap, vis);

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
@@ -11,14 +11,14 @@ import java.lang.reflect.Type;
 public abstract class PersistedObject
 extends PersistedContainer{
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis
+    final MontoyaApi api, final String name, final Preferences.Visibility vis
   ){
     this(api, name, vis, new DefaultGsonProvider());
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider
   ){
     this(
       api, name, vis,
@@ -27,8 +27,8 @@ extends PersistedContainer{
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    ILogProvider logProvider
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final ILogProvider logProvider
   ){
     this(
       api, name, vis,
@@ -37,8 +37,8 @@ extends PersistedContainer{
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider, ILogProvider logProvider
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider, final ILogProvider logProvider
   ){
     this(
       api, name, vis,
@@ -48,16 +48,16 @@ extends PersistedContainer{
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final String namespace
   ){
     this(api, name, vis, new DefaultGsonProvider(), namespace);
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -67,9 +67,9 @@ extends PersistedContainer{
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    ILogProvider logProvider,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final ILogProvider logProvider,
+    final String namespace
   ){
     this(
       api, name, vis,
@@ -79,9 +79,9 @@ extends PersistedContainer{
   }
 
   public PersistedObject(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider, ILogProvider logProvider,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider, final ILogProvider logProvider,
+    final String namespace
   ){
     super(api, name, gsonProvider, logProvider, namespace);
     _vis = vis;

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
@@ -35,19 +35,13 @@ extends PersistedContainer{
   //  needs to be handled by the child class
   protected void reset(){ _prefs.reset(_PERSISTED_NAME); }
 
-  //calls child class no-arg constructor
-  //  to get the default value of the object
   protected void register(){
-    try{
-      Class<?> thisClazz = this.getClass();
-      Constructor<?> constr = thisClazz.getDeclaredConstructor();
-      constr.setAccessible(true);
-      this.register(thisClazz, constr.newInstance());
-    }
-    catch(NoSuchMethodException | InvocationTargetException |
-      InstantiationException | IllegalAccessException e){
-      throw new RuntimeException(e);
-    }
+    Class<?> thisClazz = this.getClass();
+    PersistedObject thisDefaultClone = GsonUtilities.clone(
+      this, thisClazz, _prefs.getGsonProvider().getGson()
+    );
+
+    this.register(thisClazz, thisDefaultClone);
   }
 
   protected void register(Type persistedType, Object defaultValue){
@@ -55,11 +49,4 @@ extends PersistedContainer{
   }
 
   private final transient Preferences.Visibility _vis;
-
-  //DO NOT USE!
-  //disabled no-arg constructor
-  private PersistedObject(){
-    super(null, null, null);
-    _vis = null;
-  }
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
@@ -22,7 +22,7 @@ extends PersistedContainer{
   ){
     this(
       api, name, vis,
-      new DefaultGsonProvider(), (ILogProvider)null
+      gsonProvider, (ILogProvider)null
     );
   }
 
@@ -42,7 +42,7 @@ extends PersistedContainer{
   ){
     this(
       api, name, vis,
-      new DefaultGsonProvider(), logProvider,
+      gsonProvider, logProvider,
       ""
     );
   }
@@ -61,7 +61,7 @@ extends PersistedContainer{
   ){
     this(
       api, name, vis,
-      new DefaultGsonProvider(), null,
+      gsonProvider, null,
       namespace
     );
   }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedObject.java
@@ -11,19 +11,79 @@ import java.lang.reflect.Type;
 public abstract class PersistedObject
 extends PersistedContainer{
   public PersistedObject(
-    MontoyaApi api,
-    String name,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis
   ){
-    this(api, new DefaultGsonProvider(), name, vis);
+    this(api, name, vis, new DefaultGsonProvider());
   }
 
   public PersistedObject(
-    MontoyaApi api, IGsonProvider gsonProvider,
-    String name,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider
   ){
-    super(api, gsonProvider, name);
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), (ILogProvider)null
+    );
+  }
+
+  public PersistedObject(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    ILogProvider logProvider
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), logProvider
+    );
+  }
+
+  public PersistedObject(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider, ILogProvider logProvider
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), logProvider,
+      ""
+    );
+  }
+
+  public PersistedObject(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    String namespace
+  ){
+    this(api, name, vis, new DefaultGsonProvider(), namespace);
+  }
+
+  public PersistedObject(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), null,
+      namespace
+    );
+  }
+
+  public PersistedObject(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    ILogProvider logProvider,
+    String namespace
+  ){
+    this(
+      api, name, vis,
+      new DefaultGsonProvider(), logProvider,
+      namespace
+    );
+  }
+
+  public PersistedObject(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider, ILogProvider logProvider,
+    String namespace
+  ){
+    super(api, name, gsonProvider, logProvider, namespace);
     _vis = vis;
   }
 

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedSet.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedSet.java
@@ -7,67 +7,67 @@ import java.util.Set;
 
 public class PersistedSet<E> extends PersistedCollection<E, Set<E>> implements Set<E>{
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis
+    final MontoyaApi api, final String name, final Preferences.Visibility vis
   ){
     super(api, name, vis, new TypeToken<Set<E>>(){});
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends Set<E>> setType
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends Set<E>> setType
   ){
     super(api, name, vis, setType);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    Set<E> defaultSet
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final Set<E> defaultSet
   ){
     super(api, name, vis, new TypeToken<Set<E>>(){}, defaultSet);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends Set<E>> setType, Set<E> defaultSet
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends Set<E>> setType, final Set<E> defaultSet
   ){
     super(api, name, vis, setType, defaultSet);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends Set<E>> setType, Set<E> defaultSet
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends Set<E>> setType, final Set<E> defaultSet
   ){
     super(api, name, vis, gsonProvider, setType, defaultSet);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final String namespace
   ){
     super(api, name, vis, new TypeToken<Set<E>>(){}, namespace);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends Set<E>> setType,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends Set<E>> setType,
+    final String namespace
   ){
     super(api, name, vis, setType, null, namespace);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    Set<E> defaultSet,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final Set<E> defaultSet,
+    final String namespace
   ){
     super(api, name, vis, new TypeToken<Set<E>>(){}, defaultSet, namespace);
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    TypeToken<? extends Set<E>> setType, Set<E> defaultSet,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final TypeToken<? extends Set<E>> setType, final Set<E> defaultSet,
+    final String namespace
   ){
     super(
       api, name, vis,
@@ -78,10 +78,10 @@ public class PersistedSet<E> extends PersistedCollection<E, Set<E>> implements S
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider,
-    TypeToken<? extends Set<E>> setType, Set<E> defaultSet,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider,
+    final TypeToken<? extends Set<E>> setType, final Set<E> defaultSet,
+    final String namespace
   ){
     super(
       api, name, vis,
@@ -92,10 +92,10 @@ public class PersistedSet<E> extends PersistedCollection<E, Set<E>> implements S
   }
 
   public PersistedSet(
-    MontoyaApi api, String name, Preferences.Visibility vis,
-    IGsonProvider gsonProvider, ILogProvider logProvider,
-    TypeToken<? extends Set<E>> setType, Set<E> defaultSet,
-    String namespace
+    final MontoyaApi api, final String name, final Preferences.Visibility vis,
+    final IGsonProvider gsonProvider, final ILogProvider logProvider,
+    final TypeToken<? extends Set<E>> setType, final Set<E> defaultSet,
+    final String namespace
   ){
     super(
       api, name, vis,

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedSet.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedSet.java
@@ -85,7 +85,7 @@ public class PersistedSet<E> extends PersistedCollection<E, Set<E>> implements S
   ){
     super(
       api, name, vis,
-      new DefaultGsonProvider(), null,
+      gsonProvider, null,
       setType, defaultSet,
       namespace
     );

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedSet.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PersistedSet.java
@@ -7,46 +7,101 @@ import java.util.Set;
 
 public class PersistedSet<E> extends PersistedCollection<E, Set<E>> implements Set<E>{
   public PersistedSet(
-    MontoyaApi api,
-    String name,
-    Preferences.Visibility vis
+    MontoyaApi api, String name, Preferences.Visibility vis
   ){
-    super(api, name, new TypeToken<Set<E>>(){}, vis);
+    super(api, name, vis, new TypeToken<Set<E>>(){});
   }
 
   public PersistedSet(
-    MontoyaApi api,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends Set<E>> setType
+  ){
+    super(api, name, vis, setType);
+  }
+
+  public PersistedSet(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    Set<E> defaultSet
+  ){
+    super(api, name, vis, new TypeToken<Set<E>>(){}, defaultSet);
+  }
+
+  public PersistedSet(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    TypeToken<? extends Set<E>> setType, Set<E> defaultSet
+  ){
+    super(api, name, vis, setType, defaultSet);
+  }
+
+  public PersistedSet(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
+    TypeToken<? extends Set<E>> setType, Set<E> defaultSet
+  ){
+    super(api, name, vis, gsonProvider, setType, defaultSet);
+  }
+
+  public PersistedSet(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    String namespace
+  ){
+    super(api, name, vis, new TypeToken<Set<E>>(){}, namespace);
+  }
+
+  public PersistedSet(
+    MontoyaApi api, String name, Preferences.Visibility vis,
     TypeToken<? extends Set<E>> setType,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, name, setType, vis);
+    super(api, name, vis, setType, null, namespace);
   }
 
   public PersistedSet(
-    MontoyaApi api,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
     Set<E> defaultSet,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, name, new TypeToken<Set<E>>(){}, defaultSet, vis);
+    super(api, name, vis, new TypeToken<Set<E>>(){}, defaultSet, namespace);
   }
 
   public PersistedSet(
-    MontoyaApi api,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
     TypeToken<? extends Set<E>> setType, Set<E> defaultSet,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, name, setType, defaultSet, vis);
+    super(
+      api, name, vis,
+      new DefaultGsonProvider(),
+      setType, defaultSet,
+      namespace
+    );
   }
 
   public PersistedSet(
-    MontoyaApi api, IGsonProvider gsonProvider,
-    String name,
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider,
     TypeToken<? extends Set<E>> setType, Set<E> defaultSet,
-    Preferences.Visibility vis
+    String namespace
   ){
-    super(api, gsonProvider, name, setType, defaultSet, vis);
+    super(
+      api, name, vis,
+      new DefaultGsonProvider(), null,
+      setType, defaultSet,
+      namespace
+    );
+  }
+
+  public PersistedSet(
+    MontoyaApi api, String name, Preferences.Visibility vis,
+    IGsonProvider gsonProvider, ILogProvider logProvider,
+    TypeToken<? extends Set<E>> setType, Set<E> defaultSet,
+    String namespace
+  ){
+    super(
+      api, name, vis,
+      gsonProvider, logProvider,
+      setType, defaultSet,
+      namespace
+    );
   }
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/PreferenceFactory.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/PreferenceFactory.java
@@ -8,26 +8,50 @@ public abstract class PreferenceFactory {
     protected IGsonProvider gsonProvider;
     protected ILogProvider logProvider;
 
-    public PreferenceFactory(MontoyaApi montoyaApi, IGsonProvider gsonProvider,
-                             ILogProvider logProvider){
+    public PreferenceFactory(final MontoyaApi montoyaApi){
+        this.gsonProvider = new DefaultGsonProvider();
+        prefs = new Preferences(montoyaApi, gsonProvider);
+    }
+
+    public PreferenceFactory(final MontoyaApi montoyaApi, final IGsonProvider gsonProvider){
+        this.gsonProvider = gsonProvider;
+        prefs = new Preferences(montoyaApi, gsonProvider);
+    }
+
+    public PreferenceFactory(final MontoyaApi montoyaApi, final ILogProvider logProvider){
+        this.gsonProvider = new DefaultGsonProvider();
+        this.logProvider  = logProvider;
+        prefs = new Preferences(montoyaApi, gsonProvider, logProvider);
+    }
+
+    public PreferenceFactory(final MontoyaApi montoyaApi, final IGsonProvider gsonProvider,
+                             final ILogProvider logProvider){
         this.gsonProvider = gsonProvider;
         this.logProvider = logProvider;
         prefs = new Preferences(montoyaApi, gsonProvider, logProvider);
     }
 
-    public PreferenceFactory(MontoyaApi montoyaApi, IGsonProvider gsonProvider){
+    public PreferenceFactory(final MontoyaApi montoyaApi, final String namespace){
+        this.gsonProvider = new DefaultGsonProvider();
+        prefs = new Preferences(montoyaApi, gsonProvider, namespace);
+    }
+
+    public PreferenceFactory(final MontoyaApi montoyaApi, final IGsonProvider gsonProvider, final String namespace){
         this.gsonProvider = gsonProvider;
-        prefs = new Preferences(montoyaApi, gsonProvider);
+        prefs = new Preferences(montoyaApi, gsonProvider, namespace);
     }
 
-    public PreferenceFactory(MontoyaApi montoyaApi){
+    public PreferenceFactory(final MontoyaApi montoyaApi, final ILogProvider logProvider, final String namespace){
         this.gsonProvider = new DefaultGsonProvider();
-        prefs = new Preferences(montoyaApi, gsonProvider);
+        this.logProvider  = logProvider;
+        prefs = new Preferences(montoyaApi, gsonProvider, logProvider, namespace);
     }
 
-    public PreferenceFactory(MontoyaApi montoyaApi, ILogProvider logProvider){
-        this.gsonProvider = new DefaultGsonProvider();
-        prefs = new Preferences(montoyaApi, gsonProvider, logProvider);
+    public PreferenceFactory(final MontoyaApi montoyaApi, final IGsonProvider gsonProvider,
+                             final ILogProvider logProvider, final String namespace){
+        this.gsonProvider = gsonProvider;
+        this.logProvider  = logProvider;
+        prefs = new Preferences(montoyaApi, gsonProvider, logProvider, namespace);
     }
 
     protected abstract void createDefaults();

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
@@ -66,7 +66,7 @@ public class Preferences {
         this.montoya = montoyaApi;
         this.gsonProvider = gsonProvider;
         this.logProvider = logProvider;
-        this.namespacePrefix = namespace + ".";
+        this.namespacePrefix = (namespace.isEmpty()) ? namespace : namespace + ".";
         this.preferenceDefaults = new HashMap<>();
         this.preferences = new HashMap<>();
         this.preferenceTypes = new HashMap<>();
@@ -267,10 +267,14 @@ public class Preferences {
 
     public <T> T get(String settingName){
         settingName = namespacePrefix + settingName;
-        Visibility visibility = this.preferenceVisibilities.get(settingName);
-        if(visibility == null) throw new RuntimeException("Setting " + settingName + " has not been registered!");
+        return getRaw(settingName);
+    }
 
-        Object value = this.preferences.get(settingName);
+    private <T> T getRaw(String fullSettingName){
+        Visibility visibility = this.preferenceVisibilities.get(fullSettingName);
+        if(visibility == null) throw new RuntimeException("Setting " + fullSettingName + " has not been registered!");
+
+        Object value = this.preferences.get(fullSettingName);
 
         return (T) value;
     }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
@@ -99,8 +99,9 @@ public class Preferences {
         register(settingName, type, defaultValue, visibility, true);
     }
 
-    public void register(String settingName, Type type, Object defaultValue, Visibility visibility, Boolean persistDefault) {
-        throwExceptionIfAlreadyRegistered(settingName);
+    public void register(String settingName, Type type, Object defaultValue, Visibility visibility, Boolean persistDefault){
+        NameManager.reserve(settingName);
+
         this.preferenceVisibilities.put(settingName, visibility);
         this.preferenceTypes.put(settingName, type);
         this.preferenceDefaults.put(settingName, defaultValue);

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
@@ -116,7 +116,7 @@ public class Preferences {
             this.preferences.put(settingName, previousValue);
         }else{
             if(persistDefault) reset(settingName);
-            else               this.preferences.put(settingName, clone(defaultValue, type));
+            else               this.preferences.put(settingName, cloneDefault(settingName));
         }
 
         logOutput(String.format("Registered setting: [Key=%s, Scope=%s, Type=%s, Default=%s, Value=%s, Persisted=%s]",
@@ -318,8 +318,7 @@ public class Preferences {
         Visibility visibility = this.preferenceVisibilities.get(settingName);
         if(visibility == null) throw new RuntimeException("Setting " + settingName + " has not been registered!");
 
-        Object defaultValue = this.preferenceDefaults.getOrDefault(settingName, null);
-        Object newInstance = clone(defaultValue, this.preferenceTypes.get(settingName));
+        Object newInstance = cloneDefault(settingName);
 
         this.setSetting(settingName, newInstance);
 
@@ -365,9 +364,20 @@ public class Preferences {
             logProvider.logError(errorMessage);
     }
 
-    private Object clone(Object original, Type type){
-        String jsonDefaultValue = gsonProvider.getGson().toJson(original);
-        return gsonProvider.getGson().fromJson(jsonDefaultValue, type);
+    private Object cloneSetting(String settingName){
+        throwExceptionIfNotPreviouslyRegistered(settingName);
+        Type type  = preferenceTypes.get(settingName);
+        Object src = preferences.get(settingName);
+
+        return GsonUtilities.clone(src, type, gsonProvider.getGson());
+    }
+
+    private Object cloneDefault(String settingName){
+        throwExceptionIfNotPreviouslyRegistered(settingName);
+        Type type  = preferenceTypes.get(settingName);
+        Object src = preferenceDefaults.get(settingName);
+
+        return GsonUtilities.clone(src, type, gsonProvider.getGson());
     }
 
     private void throwExceptionIfAlreadyRegistered(String settingName){


### PR DESCRIPTION
### _This_ PR should only be considered AFTER [this other PR (13)](https://github.com/CoreyD97/Burp-Montoya-Utilities/pull/13), because _this_ PR's commit history is based on the other's. If the other PR gets rejected, I will refactor this PR's code to not depend on it.

---
If this PR [name manager collision detection #13](https://github.com/CoreyD97/Burp-Montoya-Utilities/pull/13) is approved, then _this_ PR is not really _necessary_. However, from our conversations, I thought the feature could be useful nonetheless, so I went ahead an implemented it.

This change:
--------------
- Introduces the concept of namespaces. They are essentially just automatically added prefixes. If the name manger change is accepted, I think this feature is mostly useful, not for preventing collisions within the same extension (NameManager handles that better), but rather for extension devs to prevent collisions with keys of `GLOBAL` `Visibility` (`MontoyaApi.Persistence.Preferences`) from **_other_** extensions.

- Provides many more permutations of constructors for the various classes so that they can all be used easily with namespaces.
  - Since this feature isn't really _necessary_ if the `NameManager` is approved, the default ("global") namespace is the empty string.
  
- Some private functions (like `setRaw()` and `resetRaw()` had to be added to `Preferences` to easily support namespaces. All of the public non-proxy functions were modified to automatically add the namespace to the `settingName` passed by the user. However, when some of these functions are chained together, we only want to append the namespace prefix once. The `*Raw()` functions do what the old non-raw functions used to do. The non-raw functions that used to do those things are now proxies to the raw functions that add the namespace prefix before calling the raw function.
  - While `getRaw()` was not required for any use case in the library at the moment, it was added for consistency.

Example Usage
-----------------
A sample Burp Extension that uses these features can be found [here](https://github.com/CrazyKidJack/TestBurpExtensionGradle/blob/main/src/main/java/com/jSoft/burp/Main.java).

Please note that it also uses some other features for which I have submitted PRs but that may not yet have been pulled into this repo. A working version of a fork of _this_ repo with all features used by the sample extension can be found [here (tag 1.1.0-beta.0.2.1)](https://github.com/CrazyKidJack/Burp-Montoya-Utilities/tree/1.1.0-beta.0.2.1).

If you trust them, I have created releases with jars that you can load and run to save you the trouble of building:
- [BurpMontoyaUtilities](https://github.com/CrazyKidJack/Burp-Montoya-Utilities/releases/tag/1.1.0-beta.0.2.1)
- [Sample Extension](https://github.com/CrazyKidJack/TestBurpExtensionGradle/releases/tag/0.0.0-beta.0.2.0)