### PR TITLE
Update for Montoya API compatibility and Java 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 plugins {
-    id 'java'
-    id "io.freefair.lombok" version "6.5.1"
+    id 'java-library'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
 
 group = 'com.github.CoreyD97'
 
@@ -13,43 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.portswigger.burp.extensions:montoya-api:2023.3'
-    implementation "com.google.code.gson:gson:2.10"
-
-    testRuntimeOnly files("${System.properties['user.home']}/BurpSuitePro/burpsuite_pro.jar")
+    compileOnly 'net.portswigger.burp.extensions:montoya-api:2026.2'
+    api 'com.google.code.gson:gson:2.11.0'
 }
 
-jar{
-    baseName = project.name
-    from {
-        (configurations.compileClasspath).collect { it.isDirectory() ? it : zipTree(it) }
-    }{
-        exclude "META-INF/*.SF"
-        exclude "META-INF/*.DSA"
-        exclude "META-INF/*.RSA"
-    }
-}
-
-task testJar(type: Jar) {
-    baseName = project.name + "-TEST"
-    dependsOn testClasses
-    sourceSets.main.output.each {
-        from it
-    }
-    sourceSets.test.output.each {
-        from it
-    }
-
-    sourceSets.test.runtimeClasspath.each { File f ->
-        if (f.name.endsWith('.jar')) {
-            from zipTree(f)
-        } else {
-            from f
-        }
-    }
-
-}
-
-tasks.withType(Jar) {
-    destinationDir = file("$rootDir/releases")
-}

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/BurpExtensionLogger.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/BurpExtensionLogger.java
@@ -1,11 +1,13 @@
 package com.coreyd97.BurpExtenderUtilities;
 
 import burp.api.montoya.MontoyaApi;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class BurpExtensionLogger implements ILogProvider {
     final MontoyaApi montoyaApi;
+
+    public BurpExtensionLogger(MontoyaApi montoyaApi) {
+        this.montoyaApi = montoyaApi;
+    }
 
     @Override
     public void logOutput(String message) {

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/CustomTabComponent.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/CustomTabComponent.java
@@ -13,6 +13,7 @@ public class CustomTabComponent extends JPanel {
     private JTextField editableField;
     private Border editableFieldBorder;
     private JButton removeTabButton;
+    private JLabel dotIndicator;
 
     private int index;
     private boolean showIndex;
@@ -25,6 +26,7 @@ public class CustomTabComponent extends JPanel {
 
     private String originalTitle;
     private boolean wasEdited;
+    private boolean isDragging = false;
 
     public CustomTabComponent(String title){
         this(-1, title, false, false, null, false, null);
@@ -45,7 +47,7 @@ public class CustomTabComponent extends JPanel {
         this.wasEdited = false;
 
         if(this.showIndex){
-            indexLabel = new JLabel(index + ": ");
+            indexLabel = new JLabel("Step " + index + ": ");
             this.add(indexLabel, BorderLayout.WEST);
         }
 
@@ -87,6 +89,10 @@ public class CustomTabComponent extends JPanel {
             });
         }
 
+        dotIndicator = new JLabel(" ●");
+        dotIndicator.setForeground(new Color(0xE5, 0x6B, 0x22));
+        dotIndicator.setVisible(false);
+
         if(this.isRemovable) {
             removeTabButton = new JButton("x");
             removeTabButton.setFont(removeTabButton.getFont().deriveFont(10F));
@@ -97,8 +103,14 @@ public class CustomTabComponent extends JPanel {
             removeTabButton.setPreferredSize(new Dimension(20,20));
             removeTabButton.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
             removeTabButton.setBackground(new Color(0,0,0,0));
-//            add(Box.createHorizontalStrut(5));
-            add(removeTabButton, BorderLayout.EAST);
+
+            JPanel rightPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+            rightPanel.setOpaque(false);
+            rightPanel.add(dotIndicator);
+            rightPanel.add(removeTabButton);
+            add(rightPanel, BorderLayout.EAST);
+        } else {
+            add(dotIndicator, BorderLayout.EAST);
         }
 
         revalidate();
@@ -148,6 +160,7 @@ public class CustomTabComponent extends JPanel {
         }
 
         private void handleEvent(MouseEvent mouseEvent){
+            if (isDragging) return;
             if(SwingUtilities.isLeftMouseButton(mouseEvent)) {
                 if (mouseEvent.getClickCount() > 1) {
                     editLabel();
@@ -165,7 +178,7 @@ public class CustomTabComponent extends JPanel {
     public void setIndex(int index) {
         this.index = index;
         if(this.showIndex){
-            this.indexLabel.setText(index + ": ");
+            this.indexLabel.setText("Step " + index + ": ");
         }
     }
 
@@ -182,5 +195,25 @@ public class CustomTabComponent extends JPanel {
 
     public boolean wasEditedByUser() {
         return wasEdited;
+    }
+
+    public void setDragging(boolean dragging) {
+        this.isDragging = dragging;
+    }
+
+    public void showDot() {
+        dotIndicator.setVisible(true);
+        revalidate();
+        repaint();
+    }
+
+    public void hideDot() {
+        dotIndicator.setVisible(false);
+        revalidate();
+        repaint();
+    }
+
+    public boolean isDotVisible() {
+        return dotIndicator.isVisible();
     }
 }

--- a/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
+++ b/src/main/java/com/coreyd97/BurpExtenderUtilities/Preferences.java
@@ -4,8 +4,6 @@ import burp.api.montoya.MontoyaApi;
 import com.coreyd97.BurpExtenderUtilities.nameManager.NameManager;
 import com.coreyd97.BurpExtenderUtilities.TypeAdapter.AtomicIntegerTypeAdapter;
 import com.coreyd97.BurpExtenderUtilities.TypeAdapter.ByteArrayToBase64TypeAdapter;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -17,12 +15,14 @@ public class Preferences {
 
     public enum Visibility {GLOBAL, PROJECT, VOLATILE}
 
-    @Getter
-    @Setter
     private ILogProvider logProvider;
 
-    @Getter
+    public ILogProvider getLogProvider() { return logProvider; }
+    public void setLogProvider(ILogProvider logProvider) { this.logProvider = logProvider; }
+
     private final IGsonProvider gsonProvider;
+
+    public IGsonProvider getGsonProvider() { return gsonProvider; }
     private final MontoyaApi montoya;
     private final HashMap<String, Object> preferences;
     private final HashMap<String, Object> preferenceDefaults;


### PR DESCRIPTION
- Bump Montoya dependency to 2026.2 and update Gradle config (switch to java-library, Java 25 toolchain, tidy deps).
- Remove Lombok usage and add explicit getters/constructors for compatibility (`BurpExtensionLogger`, `Preferences`).
- Enhance `CustomTabComponent`: Step X labelling, drag-suppress click handling, and add a dot indicator API (`showDot`/`hideDot`/`isDotVisible`,`setDragging`).